### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete string escaping or encoding

### DIFF
--- a/examples/wasm/src/js/python-runner.js
+++ b/examples/wasm/src/js/python-runner.js
@@ -44,9 +44,6 @@ export async function runPythonAnalyzer(pythonCode) {
   // Ensure all modules are loaded
   await ensureModulesLoaded();
 
-  // Escape single quotes in code
-  const escapedCode = pythonCode.replace(/'/g, "\\'");
-
   try {
     // Run comprehensive analysis
     const result = await pyodide.runPythonAsync(`
@@ -58,7 +55,7 @@ from complexity_analyzer import analyze_complexity
 from quality_checker import check_quality
 from test_hints import suggest_tests
 
-code = '''${escapedCode}'''
+code = json.loads(${JSON.stringify(JSON.stringify(pythonCode))})
 
 # Get basic AST analysis
 analysis_result = json.loads(analyze_code(code))
@@ -102,8 +99,6 @@ export async function runSingleAnalyzer(moduleName, pythonCode) {
   const pyodide = getPyodide();
   await ensureModulesLoaded();
 
-  const escapedCode = pythonCode.replace(/'/g, "\\'");
-
   const analyzerMap = {
     security: 'from security_scanner import scan_security; scan_security(code, ast.parse(code))',
     complexity: 'from complexity_analyzer import analyze_complexity; analyze_complexity(code, ast.parse(code))',
@@ -120,7 +115,7 @@ export async function runSingleAnalyzer(moduleName, pythonCode) {
     const result = await pyodide.runPythonAsync(`
 import json
 import ast
-code = '''${escapedCode}'''
+code = json.loads(${JSON.stringify(JSON.stringify(pythonCode))})
 result = ${analyzerCall}
 json.dumps(result, indent=2)
     `);


### PR DESCRIPTION
Potential fix for [https://github.com/asears/grand-ai-hotel/security/code-scanning/8](https://github.com/asears/grand-ai-hotel/security/code-scanning/8)

In general, you should not hand-roll escaping for embedding untrusted strings into code; instead, use a well-tested encoding/serialization mechanism that treats the string as data. Here, instead of trying to “escape single quotes” and interpolating into a Python triple-quoted string, we can embed a JSON-encoded version of `pythonCode` directly into the Python snippet as a string literal. Python’s `json.loads` will then recover the exact original code, correctly handling quotes, backslashes, and any other characters.

Concretely, in `examples/wasm/src/js/python-runner.js`:

- In `runPythonAnalyzer`, remove the `escapedCode` calculation and change the embedded Python to define `code` using `json.loads` of a JSON string literal produced by `JSON.stringify(pythonCode)`, e.g.:

  ```js
  const result = await pyodide.runPythonAsync(`
  import json
  import ast
  ...
  code = json.loads(${JSON.stringify(JSON.stringify(pythonCode))})
  ...
  `);
  ```

  The outer `JSON.stringify(...)` (in JavaScript) ensures the embedded value is a valid JavaScript string literal inside the template; the inner `JSON.stringify(pythonCode)` is what Python will parse via `json.loads` to get the original code string.

- In `runSingleAnalyzer`, similarly remove the `escapedCode` line and set `code` using the same pattern with `json.loads(${JSON.stringify(JSON.stringify(pythonCode))})`.

No new imports are required in JavaScript, since `JSON` is built-in. The existing `import json` in the Python snippets is already present in `runPythonAnalyzer`, and in `runSingleAnalyzer` we can safely add `import json` once at the top of the embedded Python.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
