### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/notebooks/sample_sms.py
+++ b/notebooks/sample_sms.py
@@ -70,8 +70,11 @@ def send_message(target_phone, text_message):
         "\r\n")
 
     if VERBOSE:
+        # Avoid logging the full SIP message or clear-text sensitive data.
+        # Log only a redacted summary for debugging purposes.
+        redacted_phone = "********" + target_phone[-2:] if len(target_phone) >= 2 else "********"
         print("===SENDING===")
-        print(message)
+        print(f"Summary: sending MESSAGE to {redacted_phone}, length={len(text_message)} characters, Call-ID={call_id}")
         print()
 
     # Using UDP


### PR DESCRIPTION
Potential fix for [https://github.com/asears/grand-ai-hotel/security/code-scanning/3](https://github.com/asears/grand-ai-hotel/security/code-scanning/3)

In general, the problem is that the code logs the full SIP `message` payload, which embeds the user-provided phone number (and possibly other private details) in clear text. To fix this without changing core functionality, we should avoid printing the entire raw SIP message and instead either (a) not log it at all, or (b) log only non-sensitive, high-level information or a redacted version. Since this is in a `VERBOSE` debug block, a safe pattern is to replace `print(message)` with a summary that omits or masks the phone number and any message content.

The best minimal fix here is to:  
- Keep the `if VERBOSE:` guard and the "===SENDING===" line.  
- Replace `print(message)` with a short summary that includes only non-sensitive fields—e.g., target phone number in redacted form and message length—but does not log the entire SIP message or the full phone number.  
- Implement the redaction inline using simple string operations, to avoid adding complex dependencies.

Concretely, in `notebooks/sample_sms.py`:
- Inside `send_message`, replace the body of the `if VERBOSE:` block (lines 72–75) so that instead of `print(message)`, it prints a safe summary, such as:  
  - A sanitized phone number (e.g., last 4 digits only, or fully masked).  
  - The length of the text message.  
  - Maybe the call ID or branch if helpful and not sensitive.  
- No new imports are required; simple Python string formatting is enough.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
