### PR TITLE
Potential fix for code scanning alert no. 4: Binding a socket to all network interfaces

### DIFF
--- a/notebooks/sms_monitor.py
+++ b/notebooks/sms_monitor.py
@@ -103,8 +103,8 @@ class VoIPMSMessageListener:
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         
         try:
-            # Bind to port
-            self.sock.bind(('', self.port))
+            # Bind to specific local interface to avoid listening on all interfaces
+            self.sock.bind((self.local_ip, self.port))
             self.running = True
             
             # Listen for messages


### PR DESCRIPTION
Potential fix for [https://github.com/asears/grand-ai-hotel/security/code-scanning/4](https://github.com/asears/grand-ai-hotel/security/code-scanning/4)

In general, to fix this kind of issue you should avoid binding to the wildcard address (`''` / `0.0.0.0`) and instead bind the socket to a specific interface IP that you actually intend to listen on. If multiple interfaces must be supported, create dedicated sockets for each interface rather than one wildcard socket.

For this file, the class already computes a specific local IP via `_get_local_ip()` and stores it in `self.local_ip`, and the startup log message uses that address as the “Listening on” endpoint. The best minimal‑change fix is to bind the UDP socket to `self.local_ip` instead of the wildcard address. That preserves existing behavior for properly configured hosts (where `self.local_ip` is a valid address) and aligns the actual binding with the information shown to the user. The only code change needed is in `VoIPMSMessageListener.start`, at the `self.sock.bind(('', self.port))` call: replace the empty string with `self.local_ip`. No new imports, methods, or additional definitions are required.

Concretely, in `notebooks/sms_monitor.py`, in the `start` method around line 107, change:

```python
self.sock.bind(('', self.port))
```

to:

```python
self.sock.bind((self.local_ip, self.port))
```

This ensures the listener is restricted to the interface identified by `_get_local_ip()` (or `0.0.0.0` only if that method genuinely could not determine a more specific address, which is still better controlled behavior than unconditionally binding to all interfaces).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
